### PR TITLE
[Fix] Resolved num-bigint Compilation Error Due to Type Mismatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,7 +766,7 @@ checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
  "libc",
  "num-integer",
- "num-traits 0.2.14",
+ "num-traits 0.2.17",
  "serde 1.0.123",
  "time 0.1.43",
  "winapi 0.3.9",
@@ -1983,13 +1983,13 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.3.1"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e9a41747ae4633fce5adffb4d2e81ffc5e89593cb19917f8fb2cc5ff76507bf"
+checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits 0.2.14",
+ "num-traits 0.2.17",
 ]
 
 [[package]]
@@ -1999,19 +1999,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
- "num-traits 0.2.14",
+ "num-traits 0.2.17",
 ]
 
 [[package]]
 name = "num-rational"
-version = "0.3.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
  "autocfg",
  "num-bigint",
  "num-integer",
- "num-traits 0.2.14",
+ "num-traits 0.2.17",
 ]
 
 [[package]]
@@ -2020,14 +2020,14 @@ version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 dependencies = [
- "num-traits 0.2.14",
+ "num-traits 0.2.17",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
 ]
@@ -2072,7 +2072,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3305af35278dd29f46fcdd139e0b1fbfae2153f0e5928b39b035542dd31e37b7"
 dependencies = [
- "num-traits 0.2.14",
+ "num-traits 0.2.17",
 ]
 
 [[package]]
@@ -2221,7 +2221,7 @@ dependencies = [
  "bitflags",
  "byteorder",
  "lazy_static",
- "num-traits 0.2.14",
+ "num-traits 0.2.17",
  "quick-error",
  "rand 0.7.3",
  "rand_chacha 0.2.2",
@@ -2852,7 +2852,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0d670ce4e348a2081843569e0f79b21c99c91bb9028b3b3ecb0f050306de547"
 dependencies = [
- "num-traits 0.2.14",
+ "num-traits 0.2.17",
 ]
 
 [[package]]

--- a/echo-core/src/config.rs
+++ b/echo-core/src/config.rs
@@ -1,69 +1,69 @@
 use {
-    config,
-    serde::Deserialize,
+    config ,
+    serde::Deserialize ,
     std::{
-        net::{IpAddr, SocketAddr},
-        path::PathBuf,
-        time::Duration,
-    },
+        net::{IpAddr , SocketAddr} ,
+        path::PathBuf ,
+        time::Duration ,
+    } ,
 };
 
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone , Debug , Deserialize)]
 pub struct Config {
-    pub log4rs_file: PathBuf,
+    pub log4rs_file: PathBuf ,
 
-    pub echo_enabled: bool,
+    pub echo_enabled: bool ,
     #[serde(default = "default_echo_addr")]
-    pub echo_addr: SocketAddr,
-    pub echo_priv_key: String,
-    pub echo_srt_priv_ip: IpAddr,
-    pub echo_srt_pub_ip: Option<IpAddr>,
+    pub echo_addr: SocketAddr ,
+    pub echo_priv_key: String ,
+    pub echo_srt_priv_ip: IpAddr ,
+    pub echo_srt_pub_ip: Option<IpAddr> ,
     #[serde(default = "default_echo_srt_min_port")]
-    pub echo_srt_min_port: u16,
+    pub echo_srt_min_port: u16 ,
     #[serde(default = "default_echo_srt_max_port")]
-    pub echo_srt_max_port: u16,
+    pub echo_srt_max_port: u16 ,
     #[serde(
-        default = "default_echo_srt_connection_timeout",
+        default = "default_echo_srt_connection_timeout" ,
         with = "duration_format"
     )]
-    pub echo_srt_connection_timeout: Duration,
-    #[serde(default = "default_echo_srt_read_timeout", with = "duration_format")]
-    pub echo_srt_read_timeout: Duration,
-    #[serde(default = "default_echo_srt_latency", with = "duration_format")]
-    pub echo_srt_latency: Duration,
+    pub echo_srt_connection_timeout: Duration ,
+    #[serde(default = "default_echo_srt_read_timeout" , with = "duration_format")]
+    pub echo_srt_read_timeout: Duration ,
+    #[serde(default = "default_echo_srt_latency" , with = "duration_format")]
+    pub echo_srt_latency: Duration ,
 
-    pub hls_enabled: bool,
-    pub hls_root_dir: PathBuf,
-    #[serde(default = "default_hls_target_duration", with = "duration_format")]
-    pub hls_target_duration: Duration,
+    pub hls_enabled: bool ,
+    pub hls_root_dir: PathBuf ,
+    #[serde(default = "default_hls_target_duration" , with = "duration_format")]
+    pub hls_target_duration: Duration ,
     #[serde(default = "default_hls_prerole_dir")]
-    pub hls_prerole_dir: PathBuf,
-    pub hls_web_enabled: bool,
+    pub hls_prerole_dir: PathBuf ,
+    pub hls_web_enabled: bool ,
     #[serde(default = "default_hls_web_addr")]
-    pub hls_web_addr: SocketAddr,
-    pub hls_web_path: String,
+    pub hls_web_addr: SocketAddr ,
+    pub hls_web_path: String ,
 
-    pub rtmp_enabled: bool,
+    pub rtmp_enabled: bool ,
     #[serde(default = "default_rtmp_addr")]
-    pub rtmp_addr: SocketAddr,
-    #[serde(default = "default_rtmp_connection_timeout", with = "duration_format")]
-    pub rtmp_connection_timeout: Duration,
+    pub rtmp_addr: SocketAddr ,
+    #[serde(default = "default_rtmp_connection_timeout" , with = "duration_format")]
+    pub rtmp_connection_timeout: Duration ,
 
-    pub record_enabled: bool,
-    pub record_root_dir: PathBuf,
-    pub record_append: bool,
+    pub record_enabled: bool ,
+    pub record_root_dir: PathBuf ,
+    pub record_append: bool ,
 
-    pub stat_enabled: bool,
-    pub stat_web_enabled: bool,
+    pub stat_enabled: bool ,
+    pub stat_web_enabled: bool ,
     #[serde(default = "default_stat_web_addr")]
-    pub stat_web_addr: SocketAddr,
+    pub stat_web_addr: SocketAddr ,
 
-    #[serde(default = "default_ttl_max_duration", with = "duration_format")]
-    pub ttl_max_duration: Duration,
+    #[serde(default = "default_ttl_max_duration" , with = "duration_format")]
+    pub ttl_max_duration: Duration ,
 }
 
 fn default_echo_addr() -> SocketAddr {
-    SocketAddr::from(([0, 0, 0, 0], 5021))
+    SocketAddr::from(([0 , 0 , 0 , 0] , 5021))
 }
 
 fn default_echo_srt_connection_timeout() -> Duration {
@@ -83,11 +83,11 @@ fn default_hls_prerole_dir() -> PathBuf {
 }
 
 fn default_hls_web_addr() -> SocketAddr {
-    SocketAddr::from(([0, 0, 0, 0], 8080))
+    SocketAddr::from(([0 , 0 , 0 , 0] , 8080))
 }
 
 fn default_rtmp_addr() -> SocketAddr {
-    SocketAddr::from(([0, 0, 0, 0], 1935))
+    SocketAddr::from(([0 , 0 , 0 , 0] , 1935))
 }
 
 fn default_rtmp_connection_timeout() -> Duration {
@@ -107,7 +107,7 @@ fn default_echo_srt_latency() -> Duration {
 }
 
 fn default_stat_web_addr() -> SocketAddr {
-    SocketAddr::from(([0, 0, 0, 0], 8088))
+    SocketAddr::from(([0 , 0 , 0 , 0] , 8088))
 }
 
 fn default_ttl_max_duration() -> Duration {
@@ -116,13 +116,13 @@ fn default_ttl_max_duration() -> Duration {
 
 mod duration_format {
     use {
-        serde::{self, Deserialize, Deserializer},
-        std::time::Duration,
+        serde::{self , Deserialize , Deserializer} ,
+        std::time::Duration ,
     };
 
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<Duration, D::Error>
+    pub fn deserialize<'de , D>(deserializer: D) -> Result<Duration , D::Error>
     where
-        D: Deserializer<'de>,
+        D: Deserializer<'de> ,
     {
         let d = f64::deserialize(deserializer)?;
         Ok(Duration::from_secs_f64(d))
@@ -132,52 +132,52 @@ mod duration_format {
 impl Default for Config {
     fn default() -> Self {
         Config {
-            log4rs_file: PathBuf::from("/etc/echo/log4rs.yml"),
+            log4rs_file: PathBuf::from("/etc/echo/log4rs.yml") ,
 
             // SRT
-            echo_enabled: true,
-            echo_addr: default_echo_addr(),
-            echo_priv_key: String::from("0759230f81a40bef363d741f6b2ea274"),
-            echo_srt_priv_ip: IpAddr::from([127, 0, 0, 1]),
-            echo_srt_pub_ip: None,
-            echo_srt_min_port: default_echo_srt_min_port(),
-            echo_srt_max_port: default_echo_srt_max_port(),
-            echo_srt_connection_timeout: default_echo_srt_connection_timeout(),
-            echo_srt_read_timeout: default_echo_srt_read_timeout(),
-            echo_srt_latency: default_echo_srt_latency(),
+            echo_enabled: true ,
+            echo_addr: default_echo_addr() ,
+            echo_priv_key: String::from("0759230f81a40bef363d741f6b2ea274") ,
+            echo_srt_priv_ip: IpAddr::from([127 , 0 , 0 , 1]) ,
+            echo_srt_pub_ip: None ,
+            echo_srt_min_port: default_echo_srt_min_port() ,
+            echo_srt_max_port: default_echo_srt_max_port() ,
+            echo_srt_connection_timeout: default_echo_srt_connection_timeout() ,
+            echo_srt_read_timeout: default_echo_srt_read_timeout() ,
+            echo_srt_latency: default_echo_srt_latency() ,
 
             // HLS
-            hls_enabled: true,
-            hls_root_dir: PathBuf::from("."),
-            hls_target_duration: default_hls_target_duration(),
-            hls_prerole_dir: default_hls_prerole_dir(),
-            hls_web_enabled: true,
-            hls_web_addr: default_hls_web_addr(),
-            hls_web_path: String::from("live"),
+            hls_enabled: true ,
+            hls_root_dir: PathBuf::from(".") ,
+            hls_target_duration: default_hls_target_duration() ,
+            hls_prerole_dir: default_hls_prerole_dir() ,
+            hls_web_enabled: true ,
+            hls_web_addr: default_hls_web_addr() ,
+            hls_web_path: String::from("live") ,
 
             // RTMP
-            rtmp_enabled: true,
-            rtmp_addr: default_rtmp_addr(),
-            rtmp_connection_timeout: default_rtmp_connection_timeout(),
+            rtmp_enabled: true ,
+            rtmp_addr: default_rtmp_addr() ,
+            rtmp_connection_timeout: default_rtmp_connection_timeout() ,
 
             // Record
-            record_enabled: true,
-            record_root_dir: PathBuf::from("."),
-            record_append: false,
+            record_enabled: true ,
+            record_root_dir: PathBuf::from(".") ,
+            record_append: false ,
 
             // stat
-            stat_enabled: true,
-            stat_web_enabled: false,
-            stat_web_addr: default_stat_web_addr(),
+            stat_enabled: true ,
+            stat_web_enabled: false ,
+            stat_web_addr: default_stat_web_addr() ,
 
             // ttl
-            ttl_max_duration: default_ttl_max_duration(),
+            ttl_max_duration: default_ttl_max_duration() ,
         }
     }
 }
 
 impl Config {
-    pub fn load() -> Result<Config, config::ConfigError> {
+    pub fn load() -> Result<Config , config::ConfigError> {
         let mut s = config::Config::default();
         s.merge(config::Environment::new())?;
         let mut config: Config = s.try_into()?;
@@ -185,35 +185,35 @@ impl Config {
         Ok(config)
     }
 
-    fn check(&mut self) -> Result<(), config::ConfigError> {
+    fn check(&mut self) -> Result<() , config::ConfigError> {
         if self.echo_priv_key.len() != 32 {
             return Err(config::ConfigError::Message(String::from(
-                "The length of ECHO_PRIV_KEY must be 32",
+                "The length of ECHO_PRIV_KEY must be 32" ,
             )));
         }
         if self.echo_srt_min_port >= self.echo_srt_max_port {
             return Err(config::ConfigError::Message(String::from(
-                "ECHO_SRT_MAX_PORT must be greater than ECHO_SRT_MIN_PORT",
+                "ECHO_SRT_MAX_PORT must be greater than ECHO_SRT_MIN_PORT" ,
             )));
         }
         if self.echo_srt_min_port < 6_970 {
             return Err(config::ConfigError::Message(String::from(
-                "ECHO_SRT_MIN_PORT must be greater than or equal to 6970",
+                "ECHO_SRT_MIN_PORT must be greater than or equal to 6970" ,
             )));
         }
         if self.echo_srt_max_port > 49_150 {
             return Err(config::ConfigError::Message(String::from(
-                "ECHO_SRT_MAX_PORT must be less than or equal to 49150",
+                "ECHO_SRT_MAX_PORT must be less than or equal to 49150" ,
             )));
         }
         if self.echo_srt_connection_timeout < Duration::from_secs(10) {
             return Err(config::ConfigError::Message(String::from(
-                "ECHO_SRT_CONNECTION_TIMEOUT must be greater than or equal to 10",
+                "ECHO_SRT_CONNECTION_TIMEOUT must be greater than or equal to 10" ,
             )));
         }
         if self.echo_srt_read_timeout < Duration::from_secs(8) {
             return Err(config::ConfigError::Message(String::from(
-                "ECHO_SRT_READ_TIMEOUT must be greater than or equal to 8",
+                "ECHO_SRT_READ_TIMEOUT must be greater than or equal to 8" ,
             )));
         }
 

--- a/echo-core/src/config.rs
+++ b/echo-core/src/config.rs
@@ -1,69 +1,71 @@
 use {
-    config ,
-    serde::Deserialize ,
+    config , 
+    serde::Deserialize , 
     std::{
-        net::{IpAddr , SocketAddr} ,
-        path::PathBuf ,
-        time::Duration ,
-    } ,
+        net::{IpAddr ,  SocketAddr} , 
+        path::PathBuf , 
+        time::Duration , 
+    } , 
 };
 
-#[derive(Clone , Debug , Deserialize)]
+#[derive(Clone ,  Debug ,  Deserialize)]
 pub struct Config {
-    pub log4rs_file: PathBuf ,
+    pub log4rs_file: PathBuf , 
 
-    pub echo_enabled: bool ,
+    pub echo_enabled: bool , 
     #[serde(default = "default_echo_addr")]
-    pub echo_addr: SocketAddr ,
-    pub echo_priv_key: String ,
-    pub echo_srt_priv_ip: IpAddr ,
-    pub echo_srt_pub_ip: Option<IpAddr> ,
+    pub echo_addr: SocketAddr , 
+    pub echo_priv_key: String , 
+    pub echo_srt_priv_ip: IpAddr , 
+    pub echo_srt_pub_ip: Option<IpAddr> , 
     #[serde(default = "default_echo_srt_min_port")]
-    pub echo_srt_min_port: u16 ,
+    pub echo_srt_min_port: u16 , 
     #[serde(default = "default_echo_srt_max_port")]
-    pub echo_srt_max_port: u16 ,
+    pub echo_srt_max_port: u16 , 
     #[serde(
-        default = "default_echo_srt_connection_timeout" ,
+        default = "default_echo_srt_connection_timeout" , 
         with = "duration_format"
     )]
-    pub echo_srt_connection_timeout: Duration ,
-    #[serde(default = "default_echo_srt_read_timeout" , with = "duration_format")]
-    pub echo_srt_read_timeout: Duration ,
-    #[serde(default = "default_echo_srt_latency" , with = "duration_format")]
-    pub echo_srt_latency: Duration ,
+    pub echo_srt_connection_timeout: Duration , 
+    #[serde(default = "default_echo_srt_read_timeout" ,  with = "duration_format")]
+    pub echo_srt_read_timeout: Duration , 
+    #[serde(default = "default_echo_srt_latency" ,  with = "duration_format")]
+    pub echo_srt_latency: Duration , 
 
-    pub hls_enabled: bool ,
-    pub hls_root_dir: PathBuf ,
-    #[serde(default = "default_hls_target_duration" , with = "duration_format")]
-    pub hls_target_duration: Duration ,
+    pub hls_enabled: bool , 
+    pub hls_root_dir: PathBuf , 
+    #[serde(default = "default_hls_target_duration" ,  with = "duration_format")]
+    pub hls_target_duration: Duration , 
     #[serde(default = "default_hls_prerole_dir")]
-    pub hls_prerole_dir: PathBuf ,
-    pub hls_web_enabled: bool ,
+    pub hls_prerole_dir: PathBuf , 
+    pub hls_web_enabled: bool , 
     #[serde(default = "default_hls_web_addr")]
-    pub hls_web_addr: SocketAddr ,
-    pub hls_web_path: String ,
+    pub hls_web_addr: SocketAddr , 
+    pub hls_web_path: String , 
 
-    pub rtmp_enabled: bool ,
+    pub rtmp_enabled: bool , 
     #[serde(default = "default_rtmp_addr")]
-    pub rtmp_addr: SocketAddr ,
-    #[serde(default = "default_rtmp_connection_timeout" , with = "duration_format")]
-    pub rtmp_connection_timeout: Duration ,
+    pub rtmp_addr: SocketAddr , 
+    #[serde(default = "default_rtmp_connection_timeout" ,  with = "duration_format")]
+    pub rtmp_connection_timeout: Duration , 
 
-    pub record_enabled: bool ,
-    pub record_root_dir: PathBuf ,
-    pub record_append: bool ,
+    pub record_enabled: bool , 
+    pub record_root_dir: PathBuf , 
+    pub record_append: bool , 
 
-    pub stat_enabled: bool ,
-    pub stat_web_enabled: bool ,
+    pub stat_enabled: bool , 
+    pub stat_web_enabled: bool , 
     #[serde(default = "default_stat_web_addr")]
-    pub stat_web_addr: SocketAddr ,
+    pub stat_web_addr: SocketAddr , 
 
-    #[serde(default = "default_ttl_max_duration" , with = "duration_format")]
-    pub ttl_max_duration: Duration ,
+
+    #[serde(default = "default_ttl_max_duration" ,  with = "duration_format")]
+    pub ttl_max_duration: Duration , 
+
 }
 
 fn default_echo_addr() -> SocketAddr {
-    SocketAddr::from(([0 , 0 , 0 , 0] , 5021))
+    SocketAddr::from(([0 ,  0 ,  0 ,  0] ,  5021))
 }
 
 fn default_echo_srt_connection_timeout() -> Duration {
@@ -83,11 +85,11 @@ fn default_hls_prerole_dir() -> PathBuf {
 }
 
 fn default_hls_web_addr() -> SocketAddr {
-    SocketAddr::from(([0 , 0 , 0 , 0] , 8080))
+    SocketAddr::from(([0 ,  0 ,  0 ,  0] ,  8080))
 }
 
 fn default_rtmp_addr() -> SocketAddr {
-    SocketAddr::from(([0 , 0 , 0 , 0] , 1935))
+    SocketAddr::from(([0 ,  0 ,  0 ,  0] ,  1935))
 }
 
 fn default_rtmp_connection_timeout() -> Duration {
@@ -107,7 +109,7 @@ fn default_echo_srt_latency() -> Duration {
 }
 
 fn default_stat_web_addr() -> SocketAddr {
-    SocketAddr::from(([0 , 0 , 0 , 0] , 8088))
+    SocketAddr::from(([0 ,  0 ,  0 ,  0] ,  8088))
 }
 
 fn default_ttl_max_duration() -> Duration {
@@ -116,13 +118,13 @@ fn default_ttl_max_duration() -> Duration {
 
 mod duration_format {
     use {
-        serde::{self , Deserialize , Deserializer} ,
-        std::time::Duration ,
+        serde::{self ,  Deserialize ,  Deserializer} , 
+        std::time::Duration , 
     };
 
-    pub fn deserialize<'de , D>(deserializer: D) -> Result<Duration , D::Error>
+    pub fn deserialize<'de ,  D>(deserializer: D) -> Result<Duration ,  D::Error>
     where
-        D: Deserializer<'de> ,
+        D: Deserializer<'de> , 
     {
         let d = f64::deserialize(deserializer)?;
         Ok(Duration::from_secs_f64(d))
@@ -132,52 +134,53 @@ mod duration_format {
 impl Default for Config {
     fn default() -> Self {
         Config {
-            log4rs_file: PathBuf::from("/etc/echo/log4rs.yml") ,
+            log4rs_file: PathBuf::from("/etc/echo/log4rs.yml") , 
 
             // SRT
-            echo_enabled: true ,
-            echo_addr: default_echo_addr() ,
-            echo_priv_key: String::from("0759230f81a40bef363d741f6b2ea274") ,
-            echo_srt_priv_ip: IpAddr::from([127 , 0 , 0 , 1]) ,
-            echo_srt_pub_ip: None ,
-            echo_srt_min_port: default_echo_srt_min_port() ,
-            echo_srt_max_port: default_echo_srt_max_port() ,
-            echo_srt_connection_timeout: default_echo_srt_connection_timeout() ,
-            echo_srt_read_timeout: default_echo_srt_read_timeout() ,
-            echo_srt_latency: default_echo_srt_latency() ,
+            echo_enabled: true , 
+            echo_addr: default_echo_addr() , 
+            echo_priv_key: String::from("0759230f81a40bef363d741f6b2ea274") , 
+            echo_srt_priv_ip: IpAddr::from([127 ,  0 ,  0 ,  1]) , 
+            echo_srt_pub_ip: None , 
+            echo_srt_min_port: default_echo_srt_min_port() , 
+            echo_srt_max_port: default_echo_srt_max_port() , 
+            echo_srt_connection_timeout: default_echo_srt_connection_timeout() , 
+            echo_srt_read_timeout: default_echo_srt_read_timeout() , 
+            echo_srt_latency: default_echo_srt_latency() , 
 
             // HLS
-            hls_enabled: true ,
-            hls_root_dir: PathBuf::from(".") ,
-            hls_target_duration: default_hls_target_duration() ,
-            hls_prerole_dir: default_hls_prerole_dir() ,
-            hls_web_enabled: true ,
-            hls_web_addr: default_hls_web_addr() ,
-            hls_web_path: String::from("live") ,
+            hls_enabled: true , 
+            hls_root_dir: PathBuf::from(".") , 
+            hls_target_duration: default_hls_target_duration() , 
+            hls_prerole_dir: default_hls_prerole_dir() , 
+            hls_web_enabled: true , 
+            hls_web_addr: default_hls_web_addr() , 
+            hls_web_path: String::from("live") , 
 
             // RTMP
-            rtmp_enabled: true ,
-            rtmp_addr: default_rtmp_addr() ,
-            rtmp_connection_timeout: default_rtmp_connection_timeout() ,
+            rtmp_enabled: true , 
+            rtmp_addr: default_rtmp_addr() , 
+            rtmp_connection_timeout: default_rtmp_connection_timeout() , 
 
             // Record
-            record_enabled: true ,
-            record_root_dir: PathBuf::from(".") ,
-            record_append: false ,
+            record_enabled: true , 
+            record_root_dir: PathBuf::from(".") , 
+            record_append: false , 
 
             // stat
-            stat_enabled: true ,
-            stat_web_enabled: false ,
-            stat_web_addr: default_stat_web_addr() ,
+            stat_enabled: true , 
+            stat_web_enabled: false , 
+            stat_web_addr: default_stat_web_addr() , 
 
             // ttl
-            ttl_max_duration: default_ttl_max_duration() ,
+            ttl_max_duration: default_ttl_max_duration() , 
+
         }
     }
 }
 
 impl Config {
-    pub fn load() -> Result<Config , config::ConfigError> {
+    pub fn load() -> Result<Config ,  config::ConfigError> {
         let mut s = config::Config::default();
         s.merge(config::Environment::new())?;
         let mut config: Config = s.try_into()?;
@@ -185,35 +188,35 @@ impl Config {
         Ok(config)
     }
 
-    fn check(&mut self) -> Result<() , config::ConfigError> {
+    fn check(&mut self) -> Result<() ,  config::ConfigError> {
         if self.echo_priv_key.len() != 32 {
             return Err(config::ConfigError::Message(String::from(
-                "The length of ECHO_PRIV_KEY must be 32" ,
+                "The length of ECHO_PRIV_KEY must be 32" , 
             )));
         }
         if self.echo_srt_min_port >= self.echo_srt_max_port {
             return Err(config::ConfigError::Message(String::from(
-                "ECHO_SRT_MAX_PORT must be greater than ECHO_SRT_MIN_PORT" ,
+                "ECHO_SRT_MAX_PORT must be greater than ECHO_SRT_MIN_PORT" , 
             )));
         }
         if self.echo_srt_min_port < 6_970 {
             return Err(config::ConfigError::Message(String::from(
-                "ECHO_SRT_MIN_PORT must be greater than or equal to 6970" ,
+                "ECHO_SRT_MIN_PORT must be greater than or equal to 6970" , 
             )));
         }
         if self.echo_srt_max_port > 49_150 {
             return Err(config::ConfigError::Message(String::from(
-                "ECHO_SRT_MAX_PORT must be less than or equal to 49150" ,
+                "ECHO_SRT_MAX_PORT must be less than or equal to 49150" , 
             )));
         }
         if self.echo_srt_connection_timeout < Duration::from_secs(10) {
             return Err(config::ConfigError::Message(String::from(
-                "ECHO_SRT_CONNECTION_TIMEOUT must be greater than or equal to 10" ,
+                "ECHO_SRT_CONNECTION_TIMEOUT must be greater than or equal to 10" , 
             )));
         }
         if self.echo_srt_read_timeout < Duration::from_secs(8) {
             return Err(config::ConfigError::Message(String::from(
-                "ECHO_SRT_READ_TIMEOUT must be greater than or equal to 8" ,
+                "ECHO_SRT_READ_TIMEOUT must be greater than or equal to 8" , 
             )));
         }
 

--- a/echo-core/src/config.rs
+++ b/echo-core/src/config.rs
@@ -1,71 +1,69 @@
 use {
-    config , 
-    serde::Deserialize , 
+    config,
+    serde::Deserialize,
     std::{
-        net::{IpAddr ,  Ipv4Addr ,  SocketAddr} , 
-        path::PathBuf , 
-        time::Duration , 
-    } , 
+        net::{IpAddr, SocketAddr},
+        path::PathBuf,
+        time::Duration,
+    },
 };
 
-#[derive(Clone ,  Debug ,  Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct Config {
-    pub log4rs_file: PathBuf , 
+    pub log4rs_file: PathBuf,
 
-    pub echo_enabled: bool , 
+    pub echo_enabled: bool,
     #[serde(default = "default_echo_addr")]
-    pub echo_addr: SocketAddr , 
-    pub echo_priv_key: String , 
-    pub echo_srt_priv_ip: IpAddr , 
-    pub echo_srt_pub_ip: Option<IpAddr> , 
+    pub echo_addr: SocketAddr,
+    pub echo_priv_key: String,
+    pub echo_srt_priv_ip: IpAddr,
+    pub echo_srt_pub_ip: Option<IpAddr>,
     #[serde(default = "default_echo_srt_min_port")]
-    pub echo_srt_min_port: u16 , 
+    pub echo_srt_min_port: u16,
     #[serde(default = "default_echo_srt_max_port")]
-    pub echo_srt_max_port: u16 , 
+    pub echo_srt_max_port: u16,
     #[serde(
-        default = "default_echo_srt_connection_timeout" , 
+        default = "default_echo_srt_connection_timeout",
         with = "duration_format"
     )]
-    pub echo_srt_connection_timeout: Duration , 
-    #[serde(default = "default_echo_srt_read_timeout" ,  with = "duration_format")]
-    pub echo_srt_read_timeout: Duration , 
-    #[serde(default = "default_echo_srt_latency" ,  with = "duration_format")]
-    pub echo_srt_latency: Duration , 
+    pub echo_srt_connection_timeout: Duration,
+    #[serde(default = "default_echo_srt_read_timeout", with = "duration_format")]
+    pub echo_srt_read_timeout: Duration,
+    #[serde(default = "default_echo_srt_latency", with = "duration_format")]
+    pub echo_srt_latency: Duration,
 
-    pub hls_enabled: bool , 
-    pub hls_root_dir: PathBuf , 
-    #[serde(default = "default_hls_target_duration" ,  with = "duration_format")]
-    pub hls_target_duration: Duration , 
+    pub hls_enabled: bool,
+    pub hls_root_dir: PathBuf,
+    #[serde(default = "default_hls_target_duration", with = "duration_format")]
+    pub hls_target_duration: Duration,
     #[serde(default = "default_hls_prerole_dir")]
-    pub hls_prerole_dir: PathBuf , 
-    pub hls_web_enabled: bool , 
+    pub hls_prerole_dir: PathBuf,
+    pub hls_web_enabled: bool,
     #[serde(default = "default_hls_web_addr")]
-    pub hls_web_addr: SocketAddr , 
-    pub hls_web_path: String , 
+    pub hls_web_addr: SocketAddr,
+    pub hls_web_path: String,
 
-    pub rtmp_enabled: bool , 
+    pub rtmp_enabled: bool,
     #[serde(default = "default_rtmp_addr")]
-    pub rtmp_addr: SocketAddr , 
-    #[serde(default = "default_rtmp_connection_timeout" ,  with = "duration_format")]
-    pub rtmp_connection_timeout: Duration , 
+    pub rtmp_addr: SocketAddr,
+    #[serde(default = "default_rtmp_connection_timeout", with = "duration_format")]
+    pub rtmp_connection_timeout: Duration,
 
-    pub record_enabled: bool , 
-    pub record_root_dir: PathBuf , 
-    pub record_append: bool , 
+    pub record_enabled: bool,
+    pub record_root_dir: PathBuf,
+    pub record_append: bool,
 
-    pub stat_enabled: bool , 
-    pub stat_web_enabled: bool , 
+    pub stat_enabled: bool,
+    pub stat_web_enabled: bool,
     #[serde(default = "default_stat_web_addr")]
-    pub stat_web_addr: SocketAddr , 
+    pub stat_web_addr: SocketAddr,
 
-
-    #[serde(default = "default_ttl_max_duration" ,  with = "duration_format")]
-    pub ttl_max_duration: Duration , 
-
+    #[serde(default = "default_ttl_max_duration", with = "duration_format")]
+    pub ttl_max_duration: Duration,
 }
 
 fn default_echo_addr() -> SocketAddr {
-    SocketAddr::from(([0 ,  0 ,  0 ,  0] ,  5021))
+    SocketAddr::from(([0, 0, 0, 0], 5021))
 }
 
 fn default_echo_srt_connection_timeout() -> Duration {
@@ -85,11 +83,11 @@ fn default_hls_prerole_dir() -> PathBuf {
 }
 
 fn default_hls_web_addr() -> SocketAddr {
-    SocketAddr::from(([0 ,  0 ,  0 ,  0] ,  8080))
+    SocketAddr::from(([0, 0, 0, 0], 8080))
 }
 
 fn default_rtmp_addr() -> SocketAddr {
-    SocketAddr::from(([0 ,  0 ,  0 ,  0] ,  1935))
+    SocketAddr::from(([0, 0, 0, 0], 1935))
 }
 
 fn default_rtmp_connection_timeout() -> Duration {
@@ -109,7 +107,7 @@ fn default_echo_srt_latency() -> Duration {
 }
 
 fn default_stat_web_addr() -> SocketAddr {
-    SocketAddr::from(([0 ,  0 ,  0 ,  0] ,  8088))
+    SocketAddr::from(([0, 0, 0, 0], 8088))
 }
 
 fn default_ttl_max_duration() -> Duration {
@@ -118,13 +116,13 @@ fn default_ttl_max_duration() -> Duration {
 
 mod duration_format {
     use {
-        serde::{self ,  Deserialize ,  Deserializer} , 
-        std::time::Duration , 
+        serde::{self, Deserialize, Deserializer},
+        std::time::Duration,
     };
 
-    pub fn deserialize<'de ,  D>(deserializer: D) -> Result<Duration ,  D::Error>
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Duration, D::Error>
     where
-        D: Deserializer<'de> , 
+        D: Deserializer<'de>,
     {
         let d = f64::deserialize(deserializer)?;
         Ok(Duration::from_secs_f64(d))
@@ -134,53 +132,52 @@ mod duration_format {
 impl Default for Config {
     fn default() -> Self {
         Config {
-            log4rs_file: PathBuf::from("/etc/echo/log4rs.yml") , 
+            log4rs_file: PathBuf::from("/etc/echo/log4rs.yml"),
 
             // SRT
-            echo_enabled: true , 
-            echo_addr: default_echo_addr() , 
-            echo_priv_key: String::from("0759230f81a40bef363d741f6b2ea274") , 
-            echo_srt_priv_ip: IpAddr::from([127 ,  0 ,  0 ,  1]) , 
-            echo_srt_pub_ip: None , 
-            echo_srt_min_port: default_echo_srt_min_port() , 
-            echo_srt_max_port: default_echo_srt_max_port() , 
-            echo_srt_connection_timeout: default_echo_srt_connection_timeout() , 
-            echo_srt_read_timeout: default_echo_srt_read_timeout() , 
-            echo_srt_latency: default_echo_srt_latency() , 
+            echo_enabled: true,
+            echo_addr: default_echo_addr(),
+            echo_priv_key: String::from("0759230f81a40bef363d741f6b2ea274"),
+            echo_srt_priv_ip: IpAddr::from([127, 0, 0, 1]),
+            echo_srt_pub_ip: None,
+            echo_srt_min_port: default_echo_srt_min_port(),
+            echo_srt_max_port: default_echo_srt_max_port(),
+            echo_srt_connection_timeout: default_echo_srt_connection_timeout(),
+            echo_srt_read_timeout: default_echo_srt_read_timeout(),
+            echo_srt_latency: default_echo_srt_latency(),
 
             // HLS
-            hls_enabled: true , 
-            hls_root_dir: PathBuf::from(".") , 
-            hls_target_duration: default_hls_target_duration() , 
-            hls_prerole_dir: default_hls_prerole_dir() , 
-            hls_web_enabled: true , 
-            hls_web_addr: default_hls_web_addr() , 
-            hls_web_path: String::from("live") , 
+            hls_enabled: true,
+            hls_root_dir: PathBuf::from("."),
+            hls_target_duration: default_hls_target_duration(),
+            hls_prerole_dir: default_hls_prerole_dir(),
+            hls_web_enabled: true,
+            hls_web_addr: default_hls_web_addr(),
+            hls_web_path: String::from("live"),
 
             // RTMP
-            rtmp_enabled: true , 
-            rtmp_addr: default_rtmp_addr() , 
-            rtmp_connection_timeout: default_rtmp_connection_timeout() , 
+            rtmp_enabled: true,
+            rtmp_addr: default_rtmp_addr(),
+            rtmp_connection_timeout: default_rtmp_connection_timeout(),
 
             // Record
-            record_enabled: true , 
-            record_root_dir: PathBuf::from(".") , 
-            record_append: false , 
+            record_enabled: true,
+            record_root_dir: PathBuf::from("."),
+            record_append: false,
 
             // stat
-            stat_enabled: true , 
-            stat_web_enabled: false , 
-            stat_web_addr: default_stat_web_addr() , 
+            stat_enabled: true,
+            stat_web_enabled: false,
+            stat_web_addr: default_stat_web_addr(),
 
             // ttl
-            ttl_max_duration: default_ttl_max_duration() , 
-
+            ttl_max_duration: default_ttl_max_duration(),
         }
     }
 }
 
 impl Config {
-    pub fn load() -> Result<Config ,  config::ConfigError> {
+    pub fn load() -> Result<Config, config::ConfigError> {
         let mut s = config::Config::default();
         s.merge(config::Environment::new())?;
         let mut config: Config = s.try_into()?;
@@ -188,35 +185,35 @@ impl Config {
         Ok(config)
     }
 
-    fn check(&mut self) -> Result<() ,  config::ConfigError> {
+    fn check(&mut self) -> Result<(), config::ConfigError> {
         if self.echo_priv_key.len() != 32 {
             return Err(config::ConfigError::Message(String::from(
-                "The length of ECHO_PRIV_KEY must be 32" , 
+                "The length of ECHO_PRIV_KEY must be 32",
             )));
         }
         if self.echo_srt_min_port >= self.echo_srt_max_port {
             return Err(config::ConfigError::Message(String::from(
-                "ECHO_SRT_MAX_PORT must be greater than ECHO_SRT_MIN_PORT" , 
+                "ECHO_SRT_MAX_PORT must be greater than ECHO_SRT_MIN_PORT",
             )));
         }
         if self.echo_srt_min_port < 6_970 {
             return Err(config::ConfigError::Message(String::from(
-                "ECHO_SRT_MIN_PORT must be greater than or equal to 6970" , 
+                "ECHO_SRT_MIN_PORT must be greater than or equal to 6970",
             )));
         }
         if self.echo_srt_max_port > 49_150 {
             return Err(config::ConfigError::Message(String::from(
-                "ECHO_SRT_MAX_PORT must be less than or equal to 49150" , 
+                "ECHO_SRT_MAX_PORT must be less than or equal to 49150",
             )));
         }
         if self.echo_srt_connection_timeout < Duration::from_secs(10) {
             return Err(config::ConfigError::Message(String::from(
-                "ECHO_SRT_CONNECTION_TIMEOUT must be greater than or equal to 10" , 
+                "ECHO_SRT_CONNECTION_TIMEOUT must be greater than or equal to 10",
             )));
         }
         if self.echo_srt_read_timeout < Duration::from_secs(8) {
             return Err(config::ConfigError::Message(String::from(
-                "ECHO_SRT_READ_TIMEOUT must be greater than or equal to 8" , 
+                "ECHO_SRT_READ_TIMEOUT must be greater than or equal to 8",
             )));
         }
 

--- a/echo-rtmp/src/service.rs
+++ b/echo-rtmp/src/service.rs
@@ -1,65 +1,65 @@
 use {
-    crate::{peer::Peer ,  Error} , 
-    anyhow::Result , 
+    crate::{peer::Peer, Error},
+    anyhow::Result,
     echo_core::{
-        session::{IdGenerator ,  ManagerHandle} , 
-        Config , 
-    } , 
-    std::{io::ErrorKind as IoErrorKind ,  time::Duration} , 
-    tokio::{net::TcpListener ,  prelude::*} , 
+        session::{IdGenerator, ManagerHandle},
+        Config,
+    },
+    std::{io::ErrorKind as IoErrorKind, time::Duration},
+    tokio::{net::TcpListener, prelude::*},
 };
 
 pub struct Service {
-    config: Config , 
-    session_manager: ManagerHandle , 
-    id_gen: IdGenerator , 
+    config: Config,
+    session_manager: ManagerHandle,
+    id_gen: IdGenerator,
 }
 
 impl Service {
-    pub fn new(session_manager: ManagerHandle ,  config: Config ,  id_gen: IdGenerator) -> Self {
+    pub fn new(session_manager: ManagerHandle, config: Config, id_gen: IdGenerator) -> Self {
         Self {
-            config , 
-            session_manager , 
-            id_gen , 
+            config,
+            session_manager,
+            id_gen,
         }
     }
 
     pub async fn run(self) {
         if let Err(err) = self.handle_rtmp().await {
-            log::error!("{}" ,  err);
+            log::error!("{}", err);
         }
     }
 
     async fn handle_rtmp(&self) -> Result<()> {
         let addr = &self.config.rtmp_addr;
         let mut listener = TcpListener::bind(addr).await?;
-        log::info!("Listening for RTMP connections on {}" ,  addr);
+        log::info!("Listening for RTMP connections on {}", addr);
 
         loop {
-            let (tcp_stream ,  _addr) = listener.accept().await?;
+            let (tcp_stream, _addr) = listener.accept().await?;
             tcp_stream.set_keepalive(Some(Duration::from_secs(30)))?;
             self.process(tcp_stream);
         }
     }
 
-    fn process<S>(&self ,  stream: S)
+    fn process<S>(&self, stream: S)
     where
-        S: AsyncRead + AsyncWrite + Unpin + Send + Sync + 'static , 
+        S: AsyncRead + AsyncWrite + Unpin + Send + Sync + 'static,
     {
         let id = self.id_gen.fetch_next();
-        log::info!("New client connection: {}" ,  id);
+        log::info!("New client connection: {}", id);
         let peer = Peer::new(
-            id , 
-            stream , 
-            self.session_manager.clone() , 
-            self.config.clone() , 
+            id,
+            stream,
+            self.session_manager.clone(),
+            self.config.clone(),
         );
 
         tokio::spawn(async move {
             if let Err(err) = peer.run().await {
                 match err {
-                    Error::Disconnected(e) if e.kind() == IoErrorKind::ConnectionReset => () , 
-                    e => log::error!("{}" ,  e) , 
+                    Error::Disconnected(e) if e.kind() == IoErrorKind::ConnectionReset => (),
+                    e => log::error!("{}", e),
                 }
             }
         });

--- a/echo-rtmp/src/service.rs
+++ b/echo-rtmp/src/service.rs
@@ -1,65 +1,65 @@
 use {
-    crate::{peer::Peer, Error},
-    anyhow::Result,
+    crate::{peer::Peer ,  Error} , 
+    anyhow::Result , 
     echo_core::{
-        session::{IdGenerator, ManagerHandle},
-        Config,
-    },
-    std::{io::ErrorKind as IoErrorKind, time::Duration},
-    tokio::{net::TcpListener, prelude::*},
+        session::{IdGenerator ,  ManagerHandle} , 
+        Config , 
+    } , 
+    std::{io::ErrorKind as IoErrorKind ,  time::Duration} , 
+    tokio::{net::TcpListener ,  prelude::*} , 
 };
 
 pub struct Service {
-    config: Config,
-    session_manager: ManagerHandle,
-    id_gen: IdGenerator,
+    config: Config , 
+    session_manager: ManagerHandle , 
+    id_gen: IdGenerator , 
 }
 
 impl Service {
-    pub fn new(session_manager: ManagerHandle, config: Config, id_gen: IdGenerator) -> Self {
+    pub fn new(session_manager: ManagerHandle ,  config: Config ,  id_gen: IdGenerator) -> Self {
         Self {
-            config,
-            session_manager,
-            id_gen,
+            config , 
+            session_manager , 
+            id_gen , 
         }
     }
 
     pub async fn run(self) {
         if let Err(err) = self.handle_rtmp().await {
-            log::error!("{}", err);
+            log::error!("{}" ,  err);
         }
     }
 
     async fn handle_rtmp(&self) -> Result<()> {
         let addr = &self.config.rtmp_addr;
         let mut listener = TcpListener::bind(addr).await?;
-        log::info!("Listening for RTMP connections on {}", addr);
+        log::info!("Listening for RTMP connections on {}" ,  addr);
 
         loop {
-            let (tcp_stream, _addr) = listener.accept().await?;
+            let (tcp_stream ,  _addr) = listener.accept().await?;
             tcp_stream.set_keepalive(Some(Duration::from_secs(30)))?;
             self.process(tcp_stream);
         }
     }
 
-    fn process<S>(&self, stream: S)
+    fn process<S>(&self ,  stream: S)
     where
-        S: AsyncRead + AsyncWrite + Unpin + Send + Sync + 'static,
+        S: AsyncRead + AsyncWrite + Unpin + Send + Sync + 'static , 
     {
         let id = self.id_gen.fetch_next();
-        log::info!("New client connection: {}", id);
+        log::info!("New client connection: {}" ,  id);
         let peer = Peer::new(
-            id,
-            stream,
-            self.session_manager.clone(),
-            self.config.clone(),
+            id , 
+            stream , 
+            self.session_manager.clone() , 
+            self.config.clone() , 
         );
 
         tokio::spawn(async move {
             if let Err(err) = peer.run().await {
                 match err {
-                    Error::Disconnected(e) if e.kind() == IoErrorKind::ConnectionReset => (),
-                    e => log::error!("{}", e),
+                    Error::Disconnected(e) if e.kind() == IoErrorKind::ConnectionReset => () , 
+                    e => log::error!("{}" ,  e) , 
                 }
             }
         });

--- a/echo-types/Cargo.toml
+++ b/echo-types/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["Spoon Radio <simon@spoonradio.co>"]
 edition = "2018"
 
 [dependencies]
-serde = { version = "^1.0", features = ["derive"] }
+serde = { version = "^1.0" , features = ["derive"] }
 bincode = "^1.3"
-bytes = { version = "^0.5", features = ["serde"] }
+bytes = { version = "^0.5" , features = ["serde"] }
 async-trait = "0.1.36"
 thiserror = "^1.0"
 num-rational = "0.4.1"

--- a/echo-types/Cargo.toml
+++ b/echo-types/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["Spoon Radio <simon@spoonradio.co>"]
 edition = "2018"
 
 [dependencies]
-serde = { version = "^1.0" , features = ["derive"] }
+serde = { version = "^1.0" ,  features = ["derive"] }
 bincode = "^1.3"
-bytes = { version = "^0.5" , features = ["serde"] }
+bytes = { version = "^0.5" ,  features = ["serde"] }
 async-trait = "0.1.36"
 thiserror = "^1.0"
 num-rational = "0.4.1"

--- a/echo-types/Cargo.toml
+++ b/echo-types/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["Spoon Radio <simon@spoonradio.co>"]
 edition = "2018"
 
 [dependencies]
-serde = { version = "^1.0" ,  features = ["derive"] }
+serde = { version = "^1.0", features = ["derive"] }
 bincode = "^1.3"
-bytes = { version = "^0.5" ,  features = ["serde"] }
+bytes = { version = "^0.5", features = ["serde"] }
 async-trait = "0.1.36"
 thiserror = "^1.0"
-num-rational = "0.3"
+num-rational = "0.4.1"

--- a/mp4-rs/Cargo.toml
+++ b/mp4-rs/Cargo.toml
@@ -12,7 +12,7 @@ async = ["tokio"]
 thiserror = "^1.0"
 byteorder = "1"
 bytes = "0.5"
-num-rational = "0.3"
+num-rational = "0.4.1"
 
 [dependencies.tokio]
 version = "0.2"

--- a/mp4-rs/src/mp4box/stsc.rs
+++ b/mp4-rs/src/mp4box/stsc.rs
@@ -49,7 +49,7 @@ impl<R: Read + Seek> ReadBox<&mut R> for StscBox {
         let mut sample_id = 1;
         for i in 0..entry_count {
             let (first_chunk, samples_per_chunk) = {
-                let mut entry = entries.get_mut(i as usize).unwrap();
+                let entry = entries.get_mut(i as usize).unwrap();
                 entry.first_sample = sample_id;
                 (entry.first_chunk, entry.samples_per_chunk)
             };

--- a/srt-rs/srt-protocol/src/pending_connection/listen.rs
+++ b/srt-rs/srt-protocol/src/pending_connection/listen.rs
@@ -4,48 +4,48 @@ use crate::packet::*;
 use crate::protocol::TimeStamp;
 use crate::ConnectionSettings;
 
-use super::{cookie::gen_cookie, hsv5::gen_hsv5_response, ConnInitSettings, ConnectError};
+use super::{cookie::gen_cookie ,  hsv5::gen_hsv5_response ,  ConnInitSettings ,  ConnectError};
 use ConnectError::*;
 use ListenState::*;
 
 pub struct Listen {
-    init_settings: ConnInitSettings,
-    state: ListenState,
+    init_settings: ConnInitSettings , 
+    state: ListenState , 
 }
 
 #[derive(Clone)]
 pub struct ConclusionWaitState {
-    cookie: i32,
-    induction_response: Packet,
+    cookie: i32 , 
+    induction_response: Packet , 
 }
 
 #[derive(Clone)]
 #[allow(clippy::large_enum_variant)]
 pub enum ListenState {
-    InductionWait,
-    ConclusionWait(ConclusionWaitState),
-    Connected(ControlPacket, ConnectionSettings),
+    InductionWait , 
+    ConclusionWait(ConclusionWaitState) , 
+    Connected(ControlPacket ,  ConnectionSettings) , 
 }
 
-type ListenResult = Result<Option<(Packet, SocketAddr)>, ConnectError>;
+type ListenResult = Result<Option<(Packet ,  SocketAddr)> ,  ConnectError>;
 
 impl Listen {
     pub fn new(init_settings: ConnInitSettings) -> Listen {
         Listen {
-            state: InductionWait,
-            init_settings,
+            state: InductionWait , 
+            init_settings , 
         }
     }
     fn wait_for_induction(
-        &mut self,
-        from: SocketAddr,
-        timestamp: TimeStamp,
-        shake: HandshakeControlInfo,
+        &mut self , 
+        from: SocketAddr , 
+        timestamp: TimeStamp , 
+        shake: HandshakeControlInfo , 
     ) -> ListenResult {
         match shake.shake_type {
             ShakeType::Induction => {
                 // https://tools.ietf.org/html/draft-gg-udt-03#page-9
-                // When the server first receives the connection request from a client ,
+                // When the server first receives the connection request from a client , 
                 // it generates a cookie value according to the client address and a
                 // secret key and sends it back to the client. The client must then send
                 // back the same cookie to the server.
@@ -56,38 +56,38 @@ impl Listen {
                 // we expect HSv5 ,  so upgrade it
                 // construct a packet to send back
                 let induction_response = Packet::Control(ControlPacket {
-                    timestamp,
-                    dest_sockid: shake.socket_id,
+                    timestamp , 
+                    dest_sockid: shake.socket_id , 
                     control_type: ControlTypes::Handshake(HandshakeControlInfo {
-                        syn_cookie: cookie,
-                        socket_id: self.init_settings.local_sockid,
-                        info: HandshakeVSInfo::V5(HSV5Info::default()),
-                        init_seq_num: shake.init_seq_num,
+                        syn_cookie: cookie , 
+                        socket_id: self.init_settings.local_sockid , 
+                        info: HandshakeVSInfo::V5(HSV5Info::default()) , 
+                        init_seq_num: shake.init_seq_num , 
                         ..shake
-                    }),
+                    }) , 
                 });
 
                 // save induction message for potential later retransmit
                 let save_induction_response = induction_response.clone();
                 self.state = ConclusionWait(ConclusionWaitState {
-                    cookie,
-                    induction_response: save_induction_response,
+                    cookie , 
+                    induction_response: save_induction_response , 
                 });
-                Ok(Some((induction_response, from)))
+                Ok(Some((induction_response ,  from)))
             }
-            _ => Err(InductionExpected(shake)),
+            _ => Err(InductionExpected(shake)) , 
         }
     }
 
     fn wait_for_conclusion(
-        &mut self,
-        from: SocketAddr,
-        timestamp: TimeStamp,
-        state: ConclusionWaitState,
-        shake: HandshakeControlInfo,
+        &mut self , 
+        from: SocketAddr , 
+        timestamp: TimeStamp , 
+        state: ConclusionWaitState , 
+        shake: HandshakeControlInfo , 
     ) -> ListenResult {
         // https://tools.ietf.org/html/draft-gg-udt-03#page-10
-        // The server ,  when receiving a handshake packet and the correct cookie ,
+        // The server ,  when receiving a handshake packet and the correct cookie , 
         // compares the packet size and maximum window size with its own values
         // and set its own values as the smaller ones. The result values are
         // also sent back to the client by a response handshake packet ,  together
@@ -98,25 +98,25 @@ impl Listen {
 
         const VERSION_5: u32 = 5;
 
-        match (shake.shake_type, shake.info.version(), shake.syn_cookie) {
-            (ShakeType::Induction, _, _) => Ok(Some((state.induction_response, from))),
+        match (shake.shake_type ,  shake.info.version() ,  shake.syn_cookie) {
+            (ShakeType::Induction ,  _ ,  _) => Ok(Some((state.induction_response ,  from))) , 
             // first induction received ,  wait for response (with cookie)
-            (ShakeType::Conclusion, VERSION_5, syn_cookie) if syn_cookie == state.cookie => {
+            (ShakeType::Conclusion ,  VERSION_5 ,  syn_cookie) if syn_cookie == state.cookie => {
                 // construct a packet to send back
-                let (hsv5, connection) = gen_hsv5_response(
-                    self.init_settings.clone(),
-                    shake.init_seq_num,
-                    &shake,
-                    from,
+                let (hsv5 ,  connection) = gen_hsv5_response(
+                    self.init_settings.clone() , 
+                    shake.init_seq_num , 
+                    &shake , 
+                    from , 
                 )?;
 
                 let resp_handshake = ControlPacket {
-                    timestamp,
-                    dest_sockid: shake.socket_id,
+                    timestamp , 
+                    dest_sockid: shake.socket_id , 
                     control_type: ControlTypes::Handshake(HandshakeControlInfo {
-                        syn_cookie: state.cookie,
-                        socket_id: self.init_settings.local_sockid,
-                        info: hsv5,
+                        syn_cookie: state.cookie , 
+                        socket_id: self.init_settings.local_sockid , 
+                        info: hsv5 , 
                         // in srt/srtcore/core.cpp
                         //
                         // void CUDT::acceptAndRespond(...)
@@ -126,10 +126,10 @@ impl Listen {
                         //    m_iISN = hs->m_iISN;
                         //    ...
                         // }
-                        init_seq_num: shake.init_seq_num,
-                        shake_type: ShakeType::Conclusion,
+                        init_seq_num: shake.init_seq_num , 
+                        shake_type: ShakeType::Conclusion , 
                         ..shake // TODO: this will pass peer wrong
-                    }),
+                    }) , 
                 };
 
                 // select the smaller packet size and max window size
@@ -137,37 +137,37 @@ impl Listen {
                 // use the remote ones
 
                 // finish the connection
-                self.state = Connected(resp_handshake.clone(), connection);
+                self.state = Connected(resp_handshake.clone() ,  connection);
 
-                Ok(Some((Packet::Control(resp_handshake), from)))
+                Ok(Some((Packet::Control(resp_handshake) ,  from)))
             }
-            (ShakeType::Conclusion, VERSION_5, syn_cookie) => {
-                Err(InvalidHandshakeCookie(state.cookie, syn_cookie))
+            (ShakeType::Conclusion ,  VERSION_5 ,  syn_cookie) => {
+                Err(InvalidHandshakeCookie(state.cookie ,  syn_cookie))
             }
-            (ShakeType::Conclusion, version, _) => Err(UnsupportedProtocolVersion(version)),
-            (_, _, _) => Err(ConclusionExpected(shake)),
+            (ShakeType::Conclusion ,  version ,  _) => Err(UnsupportedProtocolVersion(version)) , 
+            (_ ,  _ ,  _) => Err(ConclusionExpected(shake)) , 
         }
     }
 
-    fn handle_control_packets(&mut self, control: ControlPacket, from: SocketAddr) -> ListenResult {
-        match (self.state.clone(), control.control_type) {
-            (InductionWait, ControlTypes::Handshake(shake)) => {
-                self.wait_for_induction(from, control.timestamp, shake)
+    fn handle_control_packets(&mut self ,  control: ControlPacket ,  from: SocketAddr) -> ListenResult {
+        match (self.state.clone() ,  control.control_type) {
+            (InductionWait ,  ControlTypes::Handshake(shake)) => {
+                self.wait_for_induction(from ,  control.timestamp ,  shake)
             }
-            (ConclusionWait(state), ControlTypes::Handshake(shake)) => {
-                self.wait_for_conclusion(from, control.timestamp, state, shake)
+            (ConclusionWait(state) ,  ControlTypes::Handshake(shake)) => {
+                self.wait_for_conclusion(from ,  control.timestamp ,  state ,  shake)
             }
-            (InductionWait, control_type) | (ConclusionWait(_), control_type) => {
+            (InductionWait ,  control_type) | (ConclusionWait(_) ,  control_type) => {
                 Err(HandshakeExpected(control_type))
             }
-            (Connected(_, _), _) => Ok(None),
+            (Connected(_ ,  _) ,  _) => Ok(None) , 
         }
     }
 
-    pub fn handle_packet(&mut self, (packet, from): (Packet, SocketAddr)) -> ListenResult {
+    pub fn handle_packet(&mut self ,  (packet ,  from): (Packet ,  SocketAddr)) -> ListenResult {
         match packet {
-            Packet::Control(control) => self.handle_control_packets(control, from),
-            Packet::Data(data) => Err(ControlExpected(data)),
+            Packet::Control(control) => self.handle_control_packets(control ,  from) , 
+            Packet::Data(data) => Err(ControlExpected(data)) , 
         }
     }
 
@@ -180,14 +180,14 @@ impl Listen {
 mod test {
     use super::*;
 
-    use std::{net::IpAddr, time::Duration};
+    use std::{net::IpAddr ,  time::Duration};
 
     use bytes::Bytes;
     use rand::random;
 
     use crate::{
-        packet::{ControlPacket, DataPacket, HandshakeControlInfo, Packet, ShakeType},
-        SrtVersion,
+        packet::{ControlPacket ,  DataPacket ,  HandshakeControlInfo ,  Packet ,  ShakeType} , 
+        SrtVersion , 
     };
 
     fn test_listen() -> Listen {
@@ -196,45 +196,45 @@ mod test {
 
     fn test_induction() -> HandshakeControlInfo {
         HandshakeControlInfo {
-            init_seq_num: random(),
-            max_packet_size: 1316,
-            max_flow_size: 256_000,
-            shake_type: ShakeType::Induction,
-            socket_id: random(),
-            syn_cookie: 0,
-            peer_addr: IpAddr::from([127, 0, 0, 1]),
-            info: HandshakeVSInfo::V5(HSV5Info::default()),
+            init_seq_num: random() , 
+            max_packet_size: 1316 , 
+            max_flow_size: 256_000 , 
+            shake_type: ShakeType::Induction , 
+            socket_id: random() , 
+            syn_cookie: 0 , 
+            peer_addr: IpAddr::from([127 ,  0 ,  0 ,  1]) , 
+            info: HandshakeVSInfo::V5(HSV5Info::default()) , 
         }
     }
 
     fn test_conclusion() -> HandshakeControlInfo {
         HandshakeControlInfo {
-            init_seq_num: random(),
-            max_packet_size: 1316,
-            max_flow_size: 256_000,
-            shake_type: ShakeType::Conclusion,
-            socket_id: random(),
-            syn_cookie: gen_cookie(&"127.0.0.1:8765".parse().unwrap()),
-            peer_addr: IpAddr::from([127, 0, 0, 1]),
+            init_seq_num: random() , 
+            max_packet_size: 1316 , 
+            max_flow_size: 256_000 , 
+            shake_type: ShakeType::Conclusion , 
+            socket_id: random() , 
+            syn_cookie: gen_cookie(&"127.0.0.1:8765".parse().unwrap()) , 
+            peer_addr: IpAddr::from([127 ,  0 ,  0 ,  1]) , 
             info: HandshakeVSInfo::V5(HSV5Info {
-                crypto_size: 0,
+                crypto_size: 0 , 
                 ext_hs: Some(SrtControlPacket::HandshakeRequest(SrtHandshake {
-                    version: SrtVersion::CURRENT,
-                    flags: SrtShakeFlags::SUPPORTED,
-                    send_latency: Duration::from_secs(1),
-                    recv_latency: Duration::from_secs(2),
-                })),
-                ext_km: None,
-                sid: None,
-            }),
+                    version: SrtVersion::CURRENT , 
+                    flags: SrtShakeFlags::SUPPORTED , 
+                    send_latency: Duration::from_secs(1) , 
+                    recv_latency: Duration::from_secs(2) , 
+                })) , 
+                ext_km: None , 
+                sid: None , 
+            }) , 
         }
     }
 
     fn build_hs_pack(i: HandshakeControlInfo) -> Packet {
         Packet::Control(ControlPacket {
-            timestamp: TimeStamp::from_micros(0),
-            dest_sockid: random(),
-            control_type: ControlTypes::Handshake(i),
+            timestamp: TimeStamp::from_micros(0) , 
+            dest_sockid: random() , 
+            control_type: ControlTypes::Handshake(i) , 
         })
     }
 
@@ -243,35 +243,18 @@ mod test {
         let mut l = test_listen();
 
         let resp = l.handle_packet((
-            build_hs_pack(test_induction()),
-            "127.0.0.1:8765".parse().unwrap(),
+            build_hs_pack(test_induction()) , 
+            "127.0.0.1:8765".parse().unwrap() , 
         ));
-        assert!(matches!(resp, Ok(Some(_))));
+        assert!(matches!(resp ,  Ok(Some(_))));
 
         let resp = l.handle_packet((
-            build_hs_pack(test_conclusion()),
-            "127.0.0.1:8765".parse().unwrap(),
+            build_hs_pack(test_conclusion()) , 
+            "127.0.0.1:8765".parse().unwrap() , 
         ));
         // make sure it returns hs_ext
-        assert!(
-            matches!(
-                resp,
-                Ok(Some((
-                    Packet::Control(ControlPacket {
-                        control_type: ControlTypes::Handshake(HandshakeControlInfo {
-                            info: HandshakeVSInfo::V5(HSV5Info {
-                                ext_hs: Some(_),
-                                ..
-                            }),
-                            ..
-                        }),
-                        ..
-                    }),
-                    _
-                )))
-            ),
-            "{:?}",
-            resp
+        assert!(matches!(resp , 
+            Ok(Some((Packet::Control(ControlPacket{control_type: ControlTypes::Handshake(HandshakeControlInfo{info: HandshakeVSInfo::V5(HSV5Info{ext_hs: Some(_) ,  ..}) ,  ..}) ,  ..}) ,  _)))) ,  "{:?}" ,  resp
         );
     }
 
@@ -280,20 +263,22 @@ mod test {
         let mut l = test_listen();
 
         let dp = DataPacket {
-            seq_number: random(),
-            message_loc: PacketLocation::ONLY,
-            in_order_delivery: false,
-            encryption: DataEncryption::None,
-            retransmitted: false,
-            message_number: random(),
-            timestamp: TimeStamp::from_micros(0),
-            dest_sockid: random(),
-            payload: Bytes::from(&b"asdf"[..]),
+            seq_number: random() , 
+            message_loc: PacketLocation::ONLY , 
+            in_order_delivery: false , 
+            encryption: DataEncryption::None , 
+            retransmitted: false , 
+            message_number: random() , 
+            timestamp: TimeStamp::from_micros(0) , 
+            dest_sockid: random() , 
+            payload: Bytes::from(&b"asdf"[..]) , 
         };
-        assert!(matches!(
-            l.handle_packet((Packet::Data(dp.clone()) ,  "127.0.0.1:8765".parse().unwrap())) ,
-            Err(ConnectError::ControlExpected(d)) if d == dp
-        ));
+        assert!(
+            matches!(
+                l.handle_packet((Packet::Data(dp.clone()) ,  "127.0.0.1:8765".parse().unwrap())) , 
+                Err(ConnectError::ControlExpected(d)) if d == dp
+            )
+        );
     }
 
     #[test]
@@ -304,12 +289,12 @@ mod test {
         assert!(matches!(
             l.handle_packet((
                 Packet::Control(ControlPacket {
-                    timestamp: TimeStamp::from_micros(0) ,
-                    dest_sockid: random() ,
+                    timestamp: TimeStamp::from_micros(0) , 
+                    dest_sockid: random() , 
                     control_type: a2.clone()
-                }) ,
+                }) , 
                 "127.0.0.1:8765".parse().unwrap()
-            )) ,
+            )) , 
             Err(ConnectError::HandshakeExpected(pack)) if pack == a2
         ));
     }
@@ -323,9 +308,9 @@ mod test {
         let shake = test_conclusion();
         assert!(matches!(
             l.handle_packet((
-                build_hs_pack(shake.clone()) ,
+                build_hs_pack(shake.clone()) , 
                 "127.0.0.1:8765".parse().unwrap()
-            )) ,
+            )) , 
             Err(ConnectError::InductionExpected(s)) if s == shake
         ));
     }
@@ -336,8 +321,8 @@ mod test {
 
         // send a rendezvous handshake after an induction
         let resp = l.handle_packet((
-            build_hs_pack(test_induction()),
-            "127.0.0.1:8765".parse().unwrap(),
+            build_hs_pack(test_induction()) , 
+            "127.0.0.1:8765".parse().unwrap() , 
         ));
         assert!(resp.is_ok());
         assert!(resp.unwrap().is_some());
@@ -346,9 +331,9 @@ mod test {
         shake.shake_type = ShakeType::Waveahand;
         assert!(matches!(
             l.handle_packet((
-                build_hs_pack(shake.clone()) ,
+                build_hs_pack(shake.clone()) , 
                 "127.0.0.1:8765".parse().unwrap()
-            )) ,
+            )) , 
             Err(ConnectError::ConclusionExpected(nc)) if nc == shake
         ))
     }
@@ -358,19 +343,19 @@ mod test {
         let mut l = test_listen();
 
         let resp = l.handle_packet((
-            build_hs_pack(test_induction()),
-            "127.0.0.1:8765".parse().unwrap(),
+            build_hs_pack(test_induction()) , 
+            "127.0.0.1:8765".parse().unwrap() , 
         ));
-        assert!(matches!(resp, Ok(Some(_))));
+        assert!(matches!(resp ,  Ok(Some(_))));
 
         let mut c = test_conclusion();
         c.info = HandshakeVSInfo::V4(SocketType::Datagram);
 
-        let resp = l.handle_packet((build_hs_pack(c), "127.0.0.1:8765".parse().unwrap()));
+        let resp = l.handle_packet((build_hs_pack(c) ,  "127.0.0.1:8765".parse().unwrap()));
 
         assert!(
-            matches!(resp, Err(ConnectError::UnsupportedProtocolVersion(4))),
-            "{:?}",
+            matches!(resp ,  Err(ConnectError::UnsupportedProtocolVersion(4))) , 
+            "{:?}" , 
             resp
         );
     }
@@ -380,19 +365,19 @@ mod test {
         let mut l = test_listen();
 
         let resp = l.handle_packet((
-            build_hs_pack(test_induction()),
-            "127.0.0.1:8765".parse().unwrap(),
+            build_hs_pack(test_induction()) , 
+            "127.0.0.1:8765".parse().unwrap() , 
         ));
-        assert!(matches!(resp, Ok(Some(_))));
+        assert!(matches!(resp ,  Ok(Some(_))));
 
         let mut c = test_conclusion();
         c.info = HandshakeVSInfo::V5(HSV5Info::default());
 
-        let resp = l.handle_packet((build_hs_pack(c), "127.0.0.1:8765".parse().unwrap()));
+        let resp = l.handle_packet((build_hs_pack(c) ,  "127.0.0.1:8765".parse().unwrap()));
 
         assert!(
-            matches!(resp, Err(ConnectError::ExpectedExtFlags)),
-            "{:?}",
+            matches!(resp ,  Err(ConnectError::ExpectedExtFlags)) , 
+            "{:?}" , 
             resp
         );
     }


### PR DESCRIPTION
## Overview
This PR addresses a compilation error encountered in the num-bigint library, caused by a type mismatch in the `div_ceil` method call. The issue was identified as a discrepancy between the expected type (`u64`) and the provided type (`&u64`).

## Issue Description
During the compilation of the num-bigint library, a type mismatch error was encountered. The `div_ceil` method expected a parameter of type `u64`, but received a reference type (`&u64`). Rust's strict type matching system does not allow such discrepancies, leading to a compilation failure.

## Resolution
To resolve this issue, the peer dependency `num-rational` was updated. This update ensures that the types align correctly with the expectations of the Rust compiler, thereby fixing the type mismatch error.

## Impacts
- **Compilation Error:** The compilation error in the num-bigint library is resolved.
- **Build Stability:** This update brings greater stability to our build process, ensuring smoother compilations in future development cycles.
- **Dependency Management:** Updating the num-rational peer dependency improves our overall dependency management, keeping our project in line with the latest standards and practices.

## Testing
The changes have been tested locally, ensuring that the num-bigint library compiles successfully and integrates well with the rest of the project.

## Request for Review
I would appreciate a review of the changes made in this PR to ensure that the fix is effective and that it aligns with our project's standards and goals. Your feedback and suggestions are highly valued.